### PR TITLE
Fix fainted pokemon switching

### DIFF
--- a/src/build/BattleController.ts
+++ b/src/build/BattleController.ts
@@ -123,9 +123,15 @@ export default class BattleController {
                 continue;
             }
 
+            const pokemonObject = this.model.getPlayerObject(faintedPlayer).getTeam()[index - 1];
+            if (pokemonObject.getHp() <= 0) {
+                console.log("Cannot switch to a fainted Pokémon. Please choose a different Pokemon");
+                continue;
+            }
+
             const switchMove = {action: 'switch', index: index - 1};
 
-            if (!this.model.isInvalidMove(1, switchMove)) {
+            if (!this.model.isInvalidMove(faintedPlayer, switchMove)) {
                 const message = this.model.handleFaintedPokemon(switchMove);
                 console.log(message);
                 return;

--- a/src/build/model/BattleModel.ts
+++ b/src/build/model/BattleModel.ts
@@ -319,4 +319,8 @@ export default class BattleModel {
     if (BattleUtils.pokemonIsDefeated(this.player2)) return 2;
     throw new Error("No player has fainted.");
   }
+
+  public getPlayerObject(playerNumber: number): Player {
+    return playerNumber === 1 ? this.player1 : this.player2;
+  }
 }


### PR DESCRIPTION
Fixed the bug where a player was allowed to switch to a fainted pokemon but couldn't switch to remianing active pokemon.